### PR TITLE
Initialize minimal Spring Boot customer support app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Build with Maven
+        run: mvn -B -DskipTests clean package

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,18 @@
-# Compiled class file
-*.class
+# IDEs
+.idea/
+*.iml
+.vscode/
 
-# Log file
+# Build outputs
+/target/
+/build/
+
+# Logs
+logs/
 *.log
 
-# BlueJ files
-*.ctxt
+# OS files
+.DS_Store
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+# Local configuration overrides
+application-local.properties

--- a/README.md
+++ b/README.md
@@ -1,29 +1,52 @@
-# Web‑based Customer Support System
+# Web-based Customer Support System
 
-A Java Spring Boot + SQL web app for ticketing, notifications, feedback, analytics, and knowledge base.
+This project is a minimal Spring Boot starter for building a customer support portal. It includes Spring MVC, Thymeleaf for server-rendered pages, and Spring Data JPA for persistence with a MySQL database.
 
-## 🎯 Objectives
-- Submit & track support tickets
-- Assign & prioritize work
-- Notify users & staff
-- Capture feedback
-- Basic analytics dashboard
+## Getting Started
 
-## 🧱 Tech Stack
-- Backend: Spring Boot (Java 17+), JPA/Hibernate
-- DB: MySQL/PostgreSQL (pick one)
-- Build: Maven or Gradle
-- Auth: Spring Security (session/JWT)
-- (Optional) Frontend: React + Vite
+1. Ensure you have Java 17 and Maven installed.
+2. Update the database credentials in `src/main/resources/application.properties` to match your local environment.
+3. Run the application:
 
-## 🚀 Quick Start (Dev)
 ```bash
-# 1) Clone
-git clone https://github.com/<org-or-user>/customer-support-system.git
-cd customer-support-system/backend
+mvn spring-boot:run
+```
 
-# 2) Configure DB: copy example and edit values
-cp src/main/resources/application.properties.example src/main/resources/application.properties
+Visit <http://localhost:8080> for the home page and <http://localhost:8080/login> for the login page.
 
-# 3) Run (Maven example)
-./mvnw spring-boot:run
+## Project Structure
+
+```
+.
+├── pom.xml
+├── src
+│   ├── main
+│   │   ├── java
+│   │   │   └── com
+│   │   │       └── group09
+│   │   │           └── customersupport
+│   │   │               ├── CustomerSupportApplication.java
+│   │   │               └── controllers
+│   │   │                   └── HomeController.java
+│   │   └── resources
+│   │       ├── application.properties
+│   │       ├── static
+│   │       │   └── css
+│   │       │       └── main.css
+│   │       └── templates
+│   │           ├── home.html
+│   │           └── login.html
+│   └── test
+│       └── java
+│           └── com
+│               └── group09
+│                   └── customersupport
+│                       └── SmokeTest.java
+└── .github
+    └── workflows
+        └── ci.yml
+```
+
+## Database Configuration
+
+The default MySQL connection URL points to `support_db` with username `root` and password `yourpassword`. Update the values in `application.properties` to match your local database credentials. You can also create an `application-local.properties` file (ignored by Git) for machine-specific overrides.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.3</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.group09</groupId>
+    <artifactId>customer-support-system</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Web-based Customer Support System</name>
+    <description>Minimal Spring Boot application for a web-based customer support system.</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/group09/customersupport/CustomerSupportApplication.java
+++ b/src/main/java/com/group09/customersupport/CustomerSupportApplication.java
@@ -1,8 +1,11 @@
+package com.group09.customersupport;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class CustomerSupportApplication {
+
     public static void main(String[] args) {
         SpringApplication.run(CustomerSupportApplication.class, args);
     }

--- a/src/main/java/com/group09/customersupport/controllers/HomeController.java
+++ b/src/main/java/com/group09/customersupport/controllers/HomeController.java
@@ -1,0 +1,18 @@
+package com.group09.customersupport.controllers;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String home() {
+        return "home";
+    }
+
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+server.port=8080
+spring.thymeleaf.cache=false
+spring.datasource.url=jdbc:mysql://localhost:3306/support_db?useSSL=false&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=yourpassword
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1,0 +1,48 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f7f9fc;
+    margin: 0;
+    padding: 2rem;
+    color: #1f2937;
+}
+
+header {
+    margin-bottom: 2rem;
+}
+
+h1 {
+    color: #1d4ed8;
+}
+
+a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 320px;
+}
+
+.auth-form input,
+.auth-form button {
+    padding: 0.5rem;
+    font-size: 1rem;
+}
+
+.auth-form button {
+    background-color: #2563eb;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+.auth-form button:hover {
+    background-color: #1d4ed8;
+}

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,10 +1,18 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Customer Support – Home</title>
+    <link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
-<h1>Hello from Customer Support System</h1>
+<header>
+    <h1>Welcome to the Customer Support System</h1>
+</header>
+<main>
+    <p>Track tickets, assist customers, and stay connected with your support team.</p>
+    <p><a href="/login">Go to Login</a></p>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Customer Support – Login</title>
+    <link rel="stylesheet" href="/css/main.css">
+</head>
+<body>
+<header>
+    <h1>Sign in to Customer Support</h1>
+</header>
+<main>
+    <form method="post" action="/login" class="auth-form">
+        <label for="email">Email</label>
+        <input id="email" name="email" type="email" required>
+
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" required>
+
+        <button type="submit">Login</button>
+    </form>
+    <p><a href="/">Back to Home</a></p>
+</main>
+</body>
+</html>

--- a/src/test/java/com/group09/customersupport/SmokeTest.java
+++ b/src/test/java/com/group09/customersupport/SmokeTest.java
@@ -1,0 +1,16 @@
+package com.group09.customersupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration"
+})
+class SmokeTest {
+
+    @Test
+    void contextLoads() {
+        // Ensures the application context loads successfully without requiring a database connection
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold a Maven-based Spring Boot project configured for web, Thymeleaf, and JPA with MySQL runtime support
- add basic home and login MVC endpoints with Thymeleaf templates and shared styling
- document project usage and set up CI plus a smoke test to ensure the application context loads without a database

## Testing
- mvn clean package

------
https://chatgpt.com/codex/tasks/task_e_68dac5cf683c832699ce6479a9e4de72